### PR TITLE
Migrate several utils

### DIFF
--- a/nengo_extras/__init__.py
+++ b/nengo_extras/__init__.py
@@ -2,4 +2,4 @@ from .version import version as __version__
 
 from .convnet import Conv2d, Pool2d
 from .neurons import FastLIF, SoftLIFRate
-from . import data, dists, graphviz, gui, networks, neurons, vision
+from . import data, dists, graphviz, gui, networks, neurons, probe, vision

--- a/nengo_extras/__init__.py
+++ b/nengo_extras/__init__.py
@@ -2,4 +2,4 @@ from .version import version as __version__
 
 from .convnet import Conv2d, Pool2d
 from .neurons import FastLIF, SoftLIFRate
-from . import networks
+from . import data, dists, gui, networks, vision

--- a/nengo_extras/__init__.py
+++ b/nengo_extras/__init__.py
@@ -2,4 +2,4 @@ from .version import version as __version__
 
 from .convnet import Conv2d, Pool2d
 from .neurons import FastLIF, SoftLIFRate
-from . import data, dists, graphviz, gui, networks, vision
+from . import data, dists, graphviz, gui, networks, neurons, vision

--- a/nengo_extras/__init__.py
+++ b/nengo_extras/__init__.py
@@ -2,4 +2,4 @@ from .version import version as __version__
 
 from .convnet import Conv2d, Pool2d
 from .neurons import FastLIF, SoftLIFRate
-from . import data, dists, gui, networks, vision
+from . import data, dists, graphviz, gui, networks, vision

--- a/nengo_extras/conftest.py
+++ b/nengo_extras/conftest.py
@@ -1,1 +1,1 @@
-from nengo.conftest import *  # noqa: F403
+from nengo.conftest import *  # noqa

--- a/nengo_extras/dists.py
+++ b/nengo_extras/dists.py
@@ -8,6 +8,7 @@ from nengo.params import NdarrayParam, NumberParam, TupleParam
 
 def gaussian_icdf(mean, std):
     import scipy.stats as sps
+
     def icdf(p):
         return sps.norm.ppf(p, scale=std, loc=mean)
 
@@ -19,6 +20,7 @@ def loggaussian_icdf(log_mean, log_std, base=np.e):
 
     mean = base**log_mean
     log_std2 = log_std * np.log(base)
+
     def icdf(p):
         return sps.lognorm.ppf(p, log_std2, scale=mean)
 
@@ -50,7 +52,7 @@ class Concatenate(Distribution):
     def sample(self, n, d=None, rng=np.random):
         assert d is None or d == self.d
         return np.column_stack(
-            [d.sample(n, rng=rng) for d in self.distributions])
+            [dist.sample(n, rng=rng) for dist in self.distributions])
 
 
 class MultivariateCopula(Distribution):
@@ -83,6 +85,7 @@ class MultivariateCopula(Distribution):
 
     def __init__(self, marginal_icdfs, rho=None):
         import scipy.stats  # we need this for sampling
+        assert scipy.stats
 
         super(MultivariateCopula, self).__init__()
         self.marginal_icdfs = marginal_icdfs

--- a/nengo_extras/graphviz.py
+++ b/nengo_extras/graphviz.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+
+def net_diagram(net):
+    """Create a .dot file showing nodes, ensmbles, and connections.
+
+    This can be useful for debugging and testing builders that manipulate
+    the model graph before construction.
+
+    Parameters
+    ----------
+    net : Network
+        A network from which objects and connections will be extracted.
+
+    Returns
+    -------
+    text : string
+        Text content of the desired .dot file.
+    """
+    objs = net.all_nodes + net.all_ensembles
+    return obj_conn_diagram(objs, net.all_connections)
+
+
+def obj_conn_diagram(objs, connections):
+    """Create a .dot file showing nodes, ensmbles, and connections.
+
+    This can be useful for debugging and testing builders that manipulate
+    the model graph before construction.
+
+    Parameters
+    ----------
+    objs : list of Nodes and Ensembles
+        All the nodes and ensembles in the model.
+    connections : list of Connections
+        All the connections in the model.
+
+    Returns
+    -------
+    text : string
+        Text content of the desired .dot file.
+    """
+    text = []
+    text.append('digraph G {')
+    for obj in objs:
+        text.append('  "%d" [label="%s"];' % (id(obj), obj.label))
+
+    def label(transform):
+        # determine the label for a connection based on its transform
+        transform = np.asarray(transform)
+        if len(transform.shape) == 0:
+            return ''
+        return '%dx%d' % transform.shape
+
+    for c in connections:
+        text.append('  "%d" -> "%d" [label="%s"];' % (
+            id(c.pre_obj), id(c.post_obj), label(c.transform)))
+    text.append('}')
+    return '\n'.join(text)

--- a/nengo_extras/gui.py
+++ b/nengo_extras/gui.py
@@ -1,7 +1,5 @@
-
-
-def preprocess_display(x, image_shape, transpose=(1, 2, 0), scale=255.,
-                       offset=0.):
+def preprocess_display(x, image_shape,
+                       transpose=(1, 2, 0), scale=255., offset=0.):
     """Basic preprocessing that reshapes, transposes, and scales an image"""
     y = x.reshape(image_shape)
     y = (y + offset) * scale

--- a/nengo_extras/neurons.py
+++ b/nengo_extras/neurons.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 import nengo
+import nengo.utils.numpy as npext
+from nengo.exceptions import ValidationError
 from nengo.params import NumberParam
 
 
@@ -120,3 +122,132 @@ class FastLIF(nengo.neurons.LIF):
         # set spiking neurons' voltages to zero, and ref. time to tau_ref
         voltage[spiked > 0] = 0
         refractory_time[spiked > 0] = self.tau_ref + spiketime
+
+
+def spikes2events(t, spikes):
+    """Return an event-based representation of spikes (i.e. spike times)"""
+    spikes = npext.array(spikes, copy=False, min_dims=2)
+    if spikes.ndim > 2:
+        raise ValidationError("Cannot handle %d-dimensional arrays"
+                              % spikes.ndim, attr='spikes')
+    if spikes.shape[-1] != len(t):
+        raise ValidationError("Last dimension of 'spikes' must equal 'len(t)'",
+                              attr='spikes')
+
+    # find nonzero elements (spikes) in each row, and translate to times
+    return [t[spike != 0] for spike in spikes]
+
+
+def _rates_isi_events(t, events, midpoint, interp):
+    import scipy.interpolate
+
+    if len(events) == 0:
+        return np.zeros_like(t)
+
+    isis = np.diff(events)
+
+    rt = np.zeros(len(events) + (1 if midpoint else 2))
+    rt[1:-1] = 0.5*(events[:-1] + events[1:]) if midpoint else events
+    rt[0], rt[-1] = t[0], t[-1]
+
+    r = np.zeros_like(rt)
+    r[1:len(isis) + 1] = 1. / isis
+
+    f = scipy.interpolate.interp1d(rt, r, kind=interp, copy=False)
+    return f(t)
+
+
+def rates_isi(t, spikes, midpoint=False, interp='zero'):
+    """Estimate firing rates from spikes using ISIs.
+
+    Parameters
+    ----------
+    t : (M,) array_like
+        The times at which raw spike data (spikes) is defined.
+    spikes : (M, N) array_like
+        The raw spike data from N neurons.
+    midpoint : bool, optional
+        If true, place interpolation points at midpoints of ISIs. Otherwise,
+        the points are placed at the beginning of ISIs.
+    interp : string, optional
+        Interpolation type, passed to `scipy.interpolate.interp1d` as the
+        `kind` parameter.
+
+    Returns
+    -------
+    rates : (M, N) array_like
+        The estimated neuron firing rates.
+    """
+    spike_times = spikes2events(t, spikes.T)
+    rates = np.zeros(spikes.shape)
+    for i, st in enumerate(spike_times):
+        rates[:, i] = _rates_isi_events(t, st, midpoint, interp)
+
+    return rates
+
+
+def lowpass_filter(x, tau, kind='expon'):
+    nt = x.shape[-1]
+
+    if kind == 'expon':
+        t = np.arange(0, 5 * tau)
+        kern = np.exp(-t / tau) / tau
+        delay = tau
+    elif kind == 'gauss':
+        std = tau / 2.
+        t = np.arange(-4 * std, 4 * std)
+        kern = np.exp(-0.5 * (t / std)**2) / np.sqrt(2 * np.pi * std**2)
+        delay = 4 * std
+    elif kind == 'alpha':
+        alpha = 1. / tau
+        t = np.arange(0, 5 * tau)
+        kern = alpha**2 * t * np.exp(-alpha * t)
+        delay = tau
+    else:
+        raise ValidationError("Unrecognized filter kind '%s'" % kind, 'kind')
+
+    delay = int(np.round(delay))
+    return np.array(
+        [np.convolve(kern, xx, mode='full')[delay:nt + delay] for xx in x])
+
+
+def rates_kernel(t, spikes, kind='gauss', tau=0.04):
+    """Estimate firing rates from spikes using a kernel.
+
+    Parameters
+    ----------
+    t : (M,) array_like
+        The times at which raw spike data (spikes) is defined.
+    spikes : (M, N) array_like
+        The raw spike data from N neurons.
+    kind : str {'expon', 'gauss', 'expogauss', 'alpha'}, optional
+        The type of kernel to use. 'expon' is an exponential kernel, 'gauss' is
+        a Gaussian (normal) kernel, 'expogauss' is an exponential followed by
+        a Gaussian, and 'alpha' is an alpha function kernel.
+    tau : float
+        The time constant for the kernel. The optimal value will depend on the
+        firing rate of the neurons, with a longer tau preferred for lower
+        firing rates. The default value of 0.04 works well across a wide range
+        of firing rates.
+    """
+    spikes = spikes.T
+    spikes = npext.array(spikes, copy=False, min_dims=2)
+    if spikes.ndim > 2:
+        raise ValidationError("Cannot handle %d-dimensional arrays"
+                              % spikes.ndim, attr='spikes')
+    if spikes.shape[-1] != len(t):
+        raise ValidationError("Last dimension of 'spikes' must equal 'len(t)'",
+                              attr='spikes')
+
+    n, nt = spikes.shape
+    dt = t[1] - t[0]
+
+    tau_i = tau / dt
+    kind = kind.lower()
+    if kind == 'expogauss':
+        rates = lowpass_filter(spikes, tau_i, kind='expon')
+        rates = lowpass_filter(rates, tau_i / 4, kind='gauss')
+    else:
+        rates = lowpass_filter(spikes, tau_i, kind=kind)
+
+    return rates.T

--- a/nengo_extras/probe.py
+++ b/nengo_extras/probe.py
@@ -1,0 +1,78 @@
+import nengo
+from nengo.utils.compat import iteritems
+
+
+def probe_all(net, recursive=False, probe_options=None,  # noqa: C901
+              **probe_args):
+    """Probes all objects in a network.
+
+    Parameters
+    ----------
+    net : nengo.Network
+    recursive : bool, optional
+        probe subnetworks recursively, False by default.
+    probe_options: dict, optional
+        A dict of the form {nengo_object_class: [attributes_to_probe]}.
+        If not specified, every probeable attribute of every object
+        will be probed.
+
+    Returns
+    -------
+    A dictionary that maps objects and their attributes to their probes.
+
+    Examples
+    --------
+
+    Probe the decoded output and spikes in all ensembles in a network and
+    its subnetworks.
+
+    ::
+
+        model = nengo.Network(label='_test_probing')
+        with model:
+            ens1 = nengo.Ensemble(n_neurons=1, dimensions=1)
+            node1 = nengo.Node(output=[0])
+            conn = nengo.Connection(node1, ens1)
+            subnet = nengo.Network(label='subnet')
+            with subnet:
+                ens2 = nengo.Ensemble(n_neurons=1, dimensions=1)
+                node2 = nengo.Node(output=[0])
+
+        probe_options = {nengo.Ensemble: ['decoded_output', 'spikes']}
+        object_probe_dict = probe(model, recursive=True,
+                                  probe_options=probe_options)
+
+    """
+
+    probes = {}
+
+    def probe_helper(net, recursive, probe_options):
+        with net:
+            for obj_type, obj_list in iteritems(net.objects):
+
+                # recursively probe subnetworks if required
+                if obj_type is nengo.Network and recursive:
+                    for subnet in obj_list:
+                        probe_helper(subnet, recursive=recursive,
+                                     probe_options=probe_options)
+
+                # probe all probeable objects
+                elif probe_options is None:
+                    for obj in obj_list:
+                        if hasattr(obj, 'probeable') and len(
+                                obj.probeable) > 0:
+                            probes[obj] = {}
+                            for probeable in obj.probeable:
+                                probes[obj][probeable] = nengo.Probe(
+                                    obj, probeable, **probe_args)
+
+                # probe specified objects only
+                elif obj_type in probe_options:
+                    for obj in obj_list:
+                        probes[obj] = {}
+                        for attr in probe_options[obj_type]:
+                            probes[obj][attr] = (
+                                nengo.Probe(obj, attr, **probe_args))
+
+    probe_helper(net, recursive, probe_options)
+    return probes

--- a/nengo_extras/tests/test_graphviz.py
+++ b/nengo_extras/tests/test_graphviz.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+import nengo
+from nengo.utils.builder import remove_passthrough_nodes
+
+from nengo_extras.graphviz import net_diagram, obj_conn_diagram
+
+
+def make_net():
+    with nengo.Network() as model:
+        D = 3
+        input = nengo.Node([1] * D, label='input')
+        a = nengo.networks.EnsembleArray(50, D, label='a')
+        b = nengo.networks.EnsembleArray(50, D, label='b')
+        output = nengo.Node(None, size_in=D, label='output')
+
+        nengo.Connection(input, a.input, synapse=0.01)
+        nengo.Connection(a.output, b.input, synapse=0.01)
+        nengo.Connection(b.output, b.input, synapse=0.01, transform=0.9)
+        nengo.Connection(a.output, a.input, synapse=0.01,
+                         transform=np.ones((D, D)))
+        nengo.Connection(b.output, output, synapse=0.01)
+    return model
+
+
+def test_net_diagram():
+    """Constructing a .dot file for a network."""
+    dot = net_diagram(make_net())
+    assert len(dot.splitlines()) == 31
+
+
+def test_obj_conn_diagram():
+    """Constructing a .dot file for a set of objects and connections."""
+    model = make_net()
+    objs = model.all_nodes + model.all_ensembles
+    conns = model.all_connections
+
+    dot = obj_conn_diagram(objs, conns)
+    assert len(dot.splitlines()) == 31
+
+    dot = obj_conn_diagram(*remove_passthrough_nodes(objs, conns))
+    assert len(dot.splitlines()) == 27

--- a/nengo_extras/tests/test_neurons.py
+++ b/nengo_extras/tests/test_neurons.py
@@ -1,8 +1,13 @@
 import nengo
 import numpy as np
+import pytest
+from nengo.dists import Choice
+from nengo.processes import WhiteSignal
+from nengo.utils.matplotlib import implot
 from nengo.utils.numpy import rms
 
 from nengo_extras import FastLIF, SoftLIFRate
+from nengo_extras.neurons import rates_isi, rates_kernel
 
 
 def test_softlifrate_rates(plt):
@@ -107,3 +112,86 @@ def test_fastlif(plt):
     actual_counts = (spikes > 0).cumsum(axis=0)
     expected_counts = np.outer(sim.trange(), math_rates)
     assert (abs(actual_counts - expected_counts) < 1).all()
+
+
+def _test_rates(Simulator, rates, plt, seed):
+    n = 100
+    intercepts = np.linspace(-0.99, 0.99, n)
+
+    model = nengo.Network(seed=seed)
+    with model:
+        model.config[nengo.Ensemble].max_rates = Choice([50])
+        model.config[nengo.Ensemble].encoders = Choice([[1]])
+        u = nengo.Node(output=WhiteSignal(2, high=5))
+        a = nengo.Ensemble(n, 1,
+                           intercepts=intercepts, neuron_type=nengo.LIFRate())
+        b = nengo.Ensemble(n, 1,
+                           intercepts=intercepts, neuron_type=nengo.LIF())
+        nengo.Connection(u, a, synapse=0)
+        nengo.Connection(u, b, synapse=0)
+        up = nengo.Probe(u)
+        ap = nengo.Probe(a.neurons)
+        bp = nengo.Probe(b.neurons)
+
+    with Simulator(model, seed=seed+1) as sim:
+        sim.run(2.)
+
+    t = sim.trange()
+    x = sim.data[up]
+    a_rates = sim.data[ap]
+    spikes = sim.data[bp]
+    b_rates = rates(t, spikes)
+
+    if plt is not None:
+        ax = plt.subplot(411)
+        plt.plot(t, x)
+        ax = plt.subplot(412)
+        implot(plt, t, intercepts, a_rates.T, ax=ax)
+        ax.set_ylabel('intercept')
+        ax = plt.subplot(413)
+        implot(plt, t, intercepts, b_rates.T, ax=ax)
+        ax.set_ylabel('intercept')
+        ax = plt.subplot(414)
+        implot(plt, t, intercepts, (b_rates - a_rates).T, ax=ax)
+        ax.set_xlabel('time [s]')
+        ax.set_ylabel('intercept')
+
+    tmask = (t > 0.1) & (t < 1.9)
+    relative_rmse = rms(b_rates[tmask] - a_rates[tmask]) / rms(a_rates[tmask])
+    return relative_rmse
+
+
+def test_rates_isi(Simulator, plt, seed):
+    pytest.importorskip('scipy')
+    rel_rmse = _test_rates(Simulator, rates_isi, plt, seed)
+    assert rel_rmse < 0.3
+
+
+def test_rates_kernel(Simulator, plt, seed):
+    rel_rmse = _test_rates(Simulator, rates_kernel, plt, seed)
+    assert rel_rmse < 0.25
+
+
+@pytest.mark.noassertions
+def test_rates(Simulator, seed, logger):
+    pytest.importorskip('scipy')
+    functions = [
+        ('isi_zero', lambda t, s: rates_isi(
+            t, s, midpoint=False, interp='zero')),
+        ('isi_midzero', lambda t, s: rates_isi(
+            t, s, midpoint=True, interp='zero')),
+        ('isi_linear', lambda t, s: rates_isi(
+            t, s, midpoint=False, interp='linear')),
+        ('isi_midlinear', lambda t, s: rates_isi(
+            t, s, midpoint=True, interp='linear')),
+        ('kernel_expon', lambda t, s: rates_kernel(t, s, kind='expon')),
+        ('kernel_gauss', lambda t, s: rates_kernel(t, s, kind='gauss')),
+        ('kernel_expogauss', lambda t, s: rates_kernel(
+            t, s, kind='expogauss')),
+        ('kernel_alpha', lambda t, s: rates_kernel(t, s, kind='alpha')),
+    ]
+
+    for name, function in functions:
+        rel_rmse = _test_rates(Simulator, function, None, seed)
+        logger.info('rate estimator: %s', name)
+        logger.info('relative RMSE: %0.4f', rel_rmse)

--- a/nengo_extras/tests/test_probe.py
+++ b/nengo_extras/tests/test_probe.py
@@ -1,0 +1,80 @@
+import pytest
+
+import nengo
+
+from nengo_extras.probe import probe_all
+
+
+@pytest.mark.parametrize("recursive", [False, True])
+def test_probe_all_recursive(recursive):
+
+    model = nengo.Network(label='test_probing')
+    with model:
+        ens1 = nengo.Ensemble(n_neurons=1, dimensions=1)
+        node1 = nengo.Node(output=[0])
+        conn = nengo.Connection(node1, ens1)
+        subnet = nengo.Network(label='subnet')
+
+        with subnet:
+            ens2 = nengo.Ensemble(n_neurons=1, dimensions=1)
+            node2 = nengo.Node(output=[0])
+
+    probes = probe_all(model, recursive=recursive)
+
+    # test top level probing
+    total_number_probes1 = len(
+        ens1.probeable) + len(node1.probeable) + len(conn.probeable)
+    assert(len(model.probes) == total_number_probes1)
+
+    # test dictionary
+    assert(len(probes[ens1]) == len(ens1.probeable))
+    assert(len(probes[node1]) == len(node1.probeable))
+    assert(len(probes[conn]) == len(conn.probeable))
+
+    # test recursive probing
+    if recursive:
+        total_number_probes2 = len(ens2.probeable) + len(node2.probeable)
+        assert(len(subnet.probes) == total_number_probes2)
+        assert(len(probes[ens2]) == len(ens2.probeable))
+        assert(len(probes[node2]) == len(node2.probeable))
+    else:
+        assert(len(subnet.probes) == 0)
+        assert ens2 not in probes
+
+
+def test_probe_all_options():
+    model = nengo.Network(label='test_probing')
+    with model:
+        ens1 = nengo.Ensemble(n_neurons=1, dimensions=1)
+        node1 = nengo.Node(output=[0])
+        nengo.Connection(node1, ens1)
+        subnet = nengo.Network(label='subnet')
+
+        with subnet:
+            nengo.Ensemble(n_neurons=1, dimensions=1)
+            nengo.Node(output=[0])
+
+    probe_all(model, recursive=True, probe_options={
+        nengo.Ensemble: ['decoded_output']})
+
+    # only probes spikes and decoded output of the ensembles
+    assert(len(model.probes) == 1)
+    assert(len(subnet.probes) == 1)
+
+
+def test_probe_all_kwargs():
+    model = nengo.Network(label='test_probing')
+    with model:
+        ens1 = nengo.Ensemble(n_neurons=1, dimensions=1)
+        node1 = nengo.Node(output=[0])
+        nengo.Connection(node1, ens1)
+        subnet = nengo.Network(label='subnet')
+
+        with subnet:
+            nengo.Ensemble(n_neurons=1, dimensions=1)
+            nengo.Node(output=[0])
+
+    probe_all(model, recursive=True, sample_every=0.1, seed=10)
+    for probe in model.probes + subnet.probes:
+        assert probe.sample_every == 0.1
+        assert probe.seed == 10

--- a/nengo_extras/version.py
+++ b/nengo_extras/version.py
@@ -1,7 +1,7 @@
-"""Nengo version information.
+"""nengo_extras version information.
 
 We use semantic versioning (see http://semver.org/).
-and confrom to PEP440 (see https://www.python.org/dev/peps/pep-0440/).
+and conform to PEP440 (see https://www.python.org/dev/peps/pep-0440/).
 '.devN' will be added to the version unless the code base represents
 a release version. Release versions are git tagged with the version.
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ exclude = __init__.py
 ignore = E123,E133,E226,E241,E242,E731,W503
 max-complexity = 10
 
-[pytest]
+[tool:pytest]
 addopts = -p nengo.tests.options
 norecursedirs = .* *.egg build dist docs *.analytics *.logs *.plots
 markers =


### PR DESCRIPTION
I went through the `nengo/utils` directory and extracted into this PR anything that seemed a bit out of place and likely unused by the majority of users.

This included the `probe_all` function, so in addition to moving it here, I added a commit to additionally probe `Neurons` and `LearningRule` instances, as was discussed in https://github.com/nengo/nengo/issues/504.