### PR TITLE
Fixed spasafe_names function to ignore additional non-SPA characters

### DIFF
--- a/nengo_extras/data.py
+++ b/nengo_extras/data.py
@@ -266,10 +266,44 @@ def load_mnist(filepath=None, validation=False):
         return train_set, test_set
 
 
-def spasafe_names(label_names):
-    vocab_names = [
-        (name.split(',')[0] if ',' in name else name).upper().replace(' ', '_')
-        for i, name in enumerate(label_names)]
+def spasafe_name(name, pre_comma_only=True):
+    """Make a name safe to use as a SPA semantic pointer name.
+
+    Ensure a name conforms with SPA name standards. Replaces hyphens and
+    spaces with underscores, removes all other characters, and makes the
+    first letter uppercase.
+
+    Parameters
+    ----------
+    pre_comma_only : boolean
+        Only use the part of a name before a/the first comma.
+    """
+    if len(name) == 0:
+        raise ValueError("Empty name.")
+
+    if pre_comma_only and ',' in name:
+        name = name.split(',')[0]  # part before first comma
+    name = name.strip()
+    name = re.sub(r'(\s|-|,)+', '_', name)  # repl space/hyphen/comma w undersc
+    name = re.sub('(^[^a-zA-Z]+)|[^a-zA-Z0-9_]+', '', name)  # del other chars
+    name = name[0].upper() + name[1:]  # capitalize first letter
+    return name
+
+
+def spasafe_names(label_names, pre_comma_only=True):
+    """Make names safe to use as SPA semantic pointer names.
+
+    Format a list of names to conform with SPA name standards. In addition
+    to running each name through ``spasafe_name``, this function numbers
+    duplicate names so they are unique.
+
+    Parameters
+    ----------
+    pre_comma_only : boolean
+        Only use the part of a name before a/the first comma.
+    """
+    vocab_names = [spasafe_name(name, pre_comma_only=pre_comma_only)
+                   for name in label_names]
 
     # number duplicates
     unique = set()

--- a/nengo_extras/tests/test_data.py
+++ b/nengo_extras/tests/test_data.py
@@ -1,6 +1,7 @@
 import numpy as np
+import pytest
 
-from nengo_extras.data import one_hot_from_labels
+from nengo_extras.data import one_hot_from_labels, spasafe_name, spasafe_names
 
 
 def test_one_hot_from_labels_int(rng):
@@ -36,3 +37,21 @@ def test_one_hot_from_labels_float(rng):
 
     y = one_hot_from_labels(labels, classes=classes)
     assert np.array_equal(y, yref)
+
+
+def test_spasafe_name():
+    assert spasafe_name('UPPER') == 'UPPER'
+    assert spasafe_name('Camel') == 'Camel'
+    assert spasafe_name('lower') == 'Lower'
+    assert spasafe_name('Under_score') == 'Under_score'
+    assert spasafe_name('Weird.,:[]^!<>=&\'"symbols') == 'Weirdsymbols'
+    assert spasafe_name('  \tWhite- \t\r\nspace  \r\n') == 'White_space'
+    assert spasafe_name('multiple correction\'s') == 'Multiple_corrections'
+    assert spasafe_name('123four') == 'Four'
+    assert spasafe_name('A') == 'A'
+    with pytest.raises(ValueError):
+        spasafe_name('')
+
+
+def test_spasafe_names():
+    assert spasafe_names(['A,B', 'A', 'c\'s']) == ['A0', 'A1', 'Cs']


### PR DESCRIPTION
Fixed spasafe_names function to ignore "-" and "'" characters in addition to the " " character.