### PR TITLE
Safe unpickling of utf8 and latin1 encodings in Python3

### DIFF
--- a/nengo_extras/convnet.py
+++ b/nengo_extras/convnet.py
@@ -236,7 +236,8 @@ class Pool2d(Process):
 
             for i in range(si):
                 for j in range(sj):
-                    xij = x[:, :, i:min(nxi2+i, nxi):sti, j:min(nxj2+j, nxj):stj]
+                    xij = x[:, :, i:min(nxi2+i, nxi):sti,
+                            j:min(nxj2+j, nxj):stj]
                     ni, nj = xij.shape[-2:]
                     if kind == 'max':
                         y[:, :, :ni, :nj] = np.maximum(y[:, :, :ni, :nj], xij)

--- a/nengo_extras/cuda_convnet.py
+++ b/nengo_extras/cuda_convnet.py
@@ -4,16 +4,16 @@ import collections
 import os
 
 import nengo
-from nengo.utils.compat import pickle
 import numpy as np
 
 from .deepnetworks import SequentialNetwork
+from .utils import cmp, pickle_load
 
 
 def load_model_pickle(loadfile):
     loadfile = os.path.expanduser(loadfile)
     with open(loadfile, 'rb') as f:
-        return pickle.load(f)
+        return pickle_load(f)
 
 
 def layer_depths(layers):
@@ -80,7 +80,7 @@ class CudaConvnetNetwork(SequentialNetwork):
 
         # sort layers
         depths = layer_depths(layers)
-        assert np.unique(depths.values()).size == len(depths)
+        assert np.unique(list(depths.values())).size == len(depths)
 
         for name in sorted(layers, key=lambda n: depths[n]):
             self._add_layer(layers[name])

--- a/nengo_extras/deepnetworks.py
+++ b/nengo_extras/deepnetworks.py
@@ -128,8 +128,8 @@ class SequentialNetwork(Network):
         return y
 
     def theano(self, sx, output_layer=None):
-        import theano
-        import theano.tensor as tt
+        # ensure we have Theano
+        import theano  # noqa: F401
 
         sy = sx
         for layer in self.layers_to(output_layer):
@@ -549,7 +549,7 @@ class PoolLayer(ProcessLayer):
 
     def theano(self, x):
         import theano.tensor as tt
-        import theano.tensor.signal.pool
+        import theano.tensor.signal.pool  # noqa: 401
 
         pool_size = self.process.pool_size
         strides = self.process.strides

--- a/nengo_extras/gui.py
+++ b/nengo_extras/gui.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import base64
+from io import BytesIO
+
 
 def preprocess_display(x, transpose=(1, 2, 0), scale=255., offset=0.):
     """Basic preprocessing that reshapes, transposes, and scales an image"""
@@ -70,17 +73,14 @@ def image_string_function(image_shape, format="PNG",
     --------
     image_function
     """
-    import base64
-    import cStringIO
-
     to_pil = image_function(
         image_shape, preprocess=preprocess, **preprocess_args)
 
     def string_function(x):
         image = to_pil(x)
-        buffer = cStringIO.StringIO()
+        buffer = BytesIO()
         image.save(buffer, format=format)
-        image_string = base64.b64encode(buffer.getvalue())
+        image_string = base64.b64encode(buffer.getvalue()).decode()
         return image_string
 
     return string_function

--- a/nengo_extras/keras.py
+++ b/nengo_extras/keras.py
@@ -125,7 +125,6 @@ class SequentialNetwork(nengo_extras.deepnetworks.SequentialNetwork):
                                    padding=padding, name=layer.name)
 
     def _add_pool2d_layer(self, layer, kind=None):
-        from .convnet import Pool2d
         shape_in = layer.input_shape[1:]
         pool_size = layer.pool_size
         strides = layer.strides
@@ -199,9 +198,10 @@ def LSUVinit(kmodel, X, tol=0.1, t_max=50):
     .. [1] Mishkin, D., & Matas, J. (2016). All you need is a good init.
        In ICLR 2016 (pp. 1-13).
     """
-    from keras.layers import Convolution2D, LocallyConnected2D, Dense
+    from keras.layers import Convolution2D, LocallyConnected2D
     import keras.backend as K
-    # f = K.function([kmodel.layers[0].input, K.learning_phase()], [klayer.output])
+    # f = K.function([kmodel.layers[0].input, K.learning_phase()],
+    #                [klayer.output])
 
     # --- orthogonalize weights
     def orthogonalize(X):

--- a/nengo_extras/tests/test_deepnetworks.py
+++ b/nengo_extras/tests/test_deepnetworks.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 
-from nengo_extras.deepnetworks import *
+from nengo_extras.deepnetworks import ConvLayer, LocalLayer, NeuronLayer
 
 
 @pytest.mark.parametrize('local', (False, True))
@@ -11,7 +11,6 @@ def test_convlayer_theano(local, rng):
     import theano
     import theano.tensor as tt
 
-    from hunse_tools.timing import tic, toc
     n = 2
     nf = 3
     nc = 4
@@ -49,6 +48,7 @@ def test_convlayer_theano(local, rng):
 
 def test_neuronlayer_softlif_theano():
     pytest.importorskip('theano')
+    pytest.importorskip('keras')
     import theano
     import theano.tensor as tt
     from nengo_extras.keras import SoftLIF as SoftLIFLayer

--- a/nengo_extras/utils.py
+++ b/nengo_extras/utils.py
@@ -1,0 +1,27 @@
+import urllib
+
+from nengo.utils.compat import pickle, PY2
+
+
+urlretrieve = urllib.urlretrieve if PY2 else urllib.request.urlretrieve
+
+
+if PY2:
+    from cStringIO import StringIO  # noqa: F401
+else:
+    from io import StringIO  # noqa: F401
+
+    def cmp(a, b):
+        return (a > b) - (a < b)
+
+
+def pickle_load(file, *args, **kwargs):
+    if not PY2:
+        kwargs.setdefault('encoding', 'latin1')
+    return pickle.load(file, *args, **kwargs)
+
+
+def pickle_load_bytes(file, *args, **kwargs):
+    if not PY2:
+        kwargs.setdefault('encoding', 'bytes')
+    return pickle.load(file, *args, **kwargs)

--- a/nengo_extras/utils.py
+++ b/nengo_extras/utils.py
@@ -8,20 +8,27 @@ urlretrieve = urllib.urlretrieve if PY2 else urllib.request.urlretrieve
 
 if PY2:
     from cStringIO import StringIO  # noqa: F401
+
+    def pickle_load(file, *args, **kwargs):
+        return pickle.load(file, *args, **kwargs)
+
 else:
     from io import StringIO  # noqa: F401
 
     def cmp(a, b):
         return (a > b) - (a < b)
 
+    from pickle import _Unpickler
+    class _UnpicklerStringsafe(_Unpickler):
+        def _decode_string(self, value):
+            if self.encoding == "bytes":
+                return value
+            else:
+                try:
+                    return value.decode(self.encoding, self.errors)
+                except UnicodeDecodeError:
+                    return value.decode('latin1')
 
-def pickle_load(file, *args, **kwargs):
-    if not PY2:
-        kwargs.setdefault('encoding', 'latin1')
-    return pickle.load(file, *args, **kwargs)
-
-
-def pickle_load_bytes(file, *args, **kwargs):
-    if not PY2:
-        kwargs.setdefault('encoding', 'bytes')
-    return pickle.load(file, *args, **kwargs)
+    def pickle_load(file, *args, **kwargs):
+        kwargs.setdefault('encoding', 'utf8')
+        return _UnpicklerStringsafe(file, **kwargs).load()


### PR DESCRIPTION
This allows Python2 pickle files to have strings encoded as either
utf8 or ascii (latin1).

The only disadvantage is that it uses the pure-python ``pickle``
implementation, rather than the faster C-based ``_pickle``. In
practice, though, this doesn't seem much slower.

I thought that I should be able to avoid doing this by setting the ``errors`` argument on ``pickle.load``. This gets passed to ``codecs.decode``, and controls what happens if an error happens when trying to decode a string. However, whatever I set as the value of ``errors``, I always get this exception: ``ValueError: Failed to encode latin1 string when unpickling a Numpy array. pickle.load(a, encoding='latin1') is assumed.``

I even tried defining my own error handler with ``codecs.register_error``, but I can't seem to get around that exception.

Anyway, should we go ahead with this? It seems like a bit of a hack, but it does let things work nicely with pickle files that use either encoding.