### PR TITLE
Fixed params to use nengo's new param syntax

### DIFF
--- a/nengo_extras/convnet.py
+++ b/nengo_extras/convnet.py
@@ -2,37 +2,9 @@ import numpy as np
 
 from nengo.exceptions import ValidationError
 from nengo.processes import Process
-from nengo.params import (EnumParam, NdarrayParam, Parameter, TupleParam,
-                          Unconfigurable)
+from nengo.params import (EnumParam, NdarrayParam, Parameter, ShapeParam,
+                          TupleParam, Unconfigurable)
 from nengo.utils.compat import is_iterable, range
-
-
-class ShapeParam(TupleParam):
-    """A parameter where the value is a tuple of integers."""
-
-    equatable = True
-
-    def __init__(self, name, default=Unconfigurable, length=None, low=0,
-                 optional=False, readonly=None):
-        super(ShapeParam, self).__init__(name, default=default, length=length,
-                                         optional=optional, readonly=readonly)
-        self.low = low
-
-    def __set__(self, instance, value):
-        try:
-            value = tuple(int(v) for v in value)
-        except TypeError:
-            raise ValidationError("Value must be castable to a tuple of ints",
-                                  attr=self.name, obj=instance)
-        Parameter.__set__(self, instance, value)
-
-    def validate(self, instance, value):
-        super(ShapeParam, self).validate(instance, value)
-        for i, v in enumerate(value):
-            if self.low is not None and v < self.low:
-                raise ValidationError(
-                    "Element %d must be >= %d (got %d)" % (i, self.low, v),
-                    attr=self.name, obj=instance)
 
 
 class Conv2d(Process):

--- a/nengo_extras/learning_rules.py
+++ b/nengo_extras/learning_rules.py
@@ -11,16 +11,21 @@ from nengo.synapses import Lowpass
 
 
 class DeltaRuleFunctionParam(FunctionParam):
-    def function_args(self, instance, function):
-        return (np.zeros(8),)
+    function_test_size = 8  # arbitrary size to test function
 
-    def validate(self, instance, function_info):
-        super(DeltaRuleFunctionParam, self).validate(instance, function_info)
+    def function_args(self, instance, function):
+        return (np.zeros(self.function_test_size),)
+
+    def coerce(self, instance, function):
+        function_info = super(DeltaRuleFunctionParam, self).coerce(instance, function)
+
         function, size = function_info
-        if function is not None and size != 8:
+        if function is not None and size != self.function_test_size:
             raise ValidationError(
                 "Function '%s' input and output sizes must be equal" %
                 function, attr=self.name, obj=instance)
+
+        return function_info
 
 
 class DeltaRule(LearningRuleType):

--- a/nengo_extras/tests/test_learning_rules.py
+++ b/nengo_extras/tests/test_learning_rules.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import nengo
+from nengo.exceptions import ValidationError
 from nengo.neurons import RectifiedLinear
 from nengo.utils.numpy import rms
 
@@ -74,3 +75,9 @@ def test_delta_rule(Simulator, seed, rng, plt):
     m = t > t_train
     rms_error = rms(y[m] - x[m]) / rms(x[m])
     assert rms_error < 0.3
+
+
+def test_delta_rule_function_param_size():
+    fn = lambda j: j[:-1]
+    with pytest.raises(ValidationError):
+        rule = DeltaRule(post_fn=fn)


### PR DESCRIPTION
Nengo now uses ``coerce`` instead of ``validate``, so this library
must adapt.

- Fixed DeltaRuleFunctionParam, and added a test
- Changed convnet.py to use ShapeParam from nengo

This depends on nengo/nengo#1342