### PR TITLE
Fix urlretrieve import in Py3

### DIFF
--- a/nengo_extras/utils.py
+++ b/nengo_extras/utils.py
@@ -1,15 +1,12 @@
-import urllib
-
 from nengo.utils.compat import pickle, PY2
-
-
-urlretrieve = urllib.urlretrieve if PY2 else urllib.request.urlretrieve
 
 
 if PY2:
     from cStringIO import StringIO  # noqa: F401
+    from urllib import urlretrieve  # noqa: F401
 else:
     from io import StringIO  # noqa: F401
+    from urllib.request import urlretrieve  # noqa: F401
 
 
 def cmp(a, b):  # same as python2's builtin cmp, not available in python3


### PR DESCRIPTION
Just ran into this using `nengo_extras` in Python 3. The issue is that `urllib` does not import the `request` submodule by default, so you have to explicitly do `from urllib.request`.